### PR TITLE
WIP: various: unwrap systemd unit bash wrappers

### DIFF
--- a/nixos/modules/security/soteria.nix
+++ b/nixos/modules/security/soteria.nix
@@ -36,8 +36,8 @@ in
       wants = [ "graphical-session.target" ];
       after = [ "graphical-session.target" ];
 
-      script = lib.getExe cfg.package;
       serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
         Type = "simple";
         Restart = "on-failure";
         RestartSec = 1;

--- a/nixos/modules/services/blockchain/ethereum/geth.nix
+++ b/nixos/modules/services/blockchain/ethereum/geth.nix
@@ -206,6 +206,43 @@ in
           after = [ "network.target" ];
 
           serviceConfig = {
+            ExecStart =
+              let
+                args = lib.cli.toCommandLineShellGNU { } {
+                  inherit (cfg)
+                    syncmode
+                    gcmode
+                    port
+                    maxpeers
+                    ;
+                  nousb = true;
+                  ipcdisable = true;
+                  datadir = dataDir;
+                  ${cfg.network} = true;
+
+                  http = cfg.http.enable;
+                  "http.addr" = if cfg.http.enable then cfg.http.address else null;
+                  "http.port" = if cfg.http.enable then cfg.http.port else null;
+                  "http.api" = if cfg.http.apis != null then lib.concatStringsSep "," cfg.http.apis else null;
+
+                  ws = cfg.websocket.enable;
+                  "ws.addr" = if cfg.websocket.enable then cfg.websocket.address else null;
+                  "ws.port" = if cfg.websocket.enable then cfg.websocket.port else null;
+                  "ws.api" = if cfg.websocket.apis != null then lib.concatStringsSep "," cfg.websocket.apis else null;
+
+                  metrics = cfg.metrics.enable;
+                  "metrics.addr" = if cfg.metrics.enable then cfg.metrics.address else null;
+                  "metrics.port" = if cfg.metrics.enable then cfg.metrics.port else null;
+
+                  "authrpc.addr" = cfg.authrpc.address;
+                  "authrpc.port" = cfg.authrpc.port;
+                  "authrpc.vhosts" = lib.concatStringsSep "," cfg.authrpc.vhosts;
+                  "authrpc.jwtsecret" =
+                    if cfg.authrpc.jwtsecret != "" then cfg.authrpc.jwtsecret else "${dataDir}/geth/jwtsecret";
+                };
+              in
+              "${lib.getExe cfg.package} ${args} ${lib.escapeShellArgs cfg.extraArgs}";
+
             DynamicUser = true;
             Restart = "always";
             StateDirectory = stateDir;
@@ -217,37 +254,6 @@ in
             PrivateDevices = "true";
             MemoryDenyWriteExecute = "true";
           };
-
-          script = ''
-            ${cfg.package}/bin/geth \
-              --nousb \
-              --ipcdisable \
-              ${lib.optionalString (cfg.network != null) ''--${cfg.network}''} \
-              --syncmode ${cfg.syncmode} \
-              --gcmode ${cfg.gcmode} \
-              --port ${toString cfg.port} \
-              --maxpeers ${toString cfg.maxpeers} \
-              ${lib.optionalString cfg.http.enable ''--http --http.addr ${cfg.http.address} --http.port ${toString cfg.http.port}''} \
-              ${
-                lib.optionalString (cfg.http.apis != null) ''--http.api ${lib.concatStringsSep "," cfg.http.apis}''
-              } \
-              ${lib.optionalString cfg.websocket.enable ''--ws --ws.addr ${cfg.websocket.address} --ws.port ${toString cfg.websocket.port}''} \
-              ${
-                lib.optionalString (
-                  cfg.websocket.apis != null
-                ) ''--ws.api ${lib.concatStringsSep "," cfg.websocket.apis}''
-              } \
-              ${lib.optionalString cfg.metrics.enable ''--metrics --metrics.addr ${cfg.metrics.address} --metrics.port ${toString cfg.metrics.port}''} \
-              --authrpc.addr ${cfg.authrpc.address} --authrpc.port ${toString cfg.authrpc.port} --authrpc.vhosts ${lib.concatStringsSep "," cfg.authrpc.vhosts} \
-              ${
-                if (cfg.authrpc.jwtsecret != "") then
-                  ''--authrpc.jwtsecret ${cfg.authrpc.jwtsecret}''
-                else
-                  ''--authrpc.jwtsecret ${dataDir}/geth/jwtsecret''
-              } \
-              ${lib.escapeShellArgs cfg.extraArgs} \
-              --datadir ${dataDir}
-          '';
         }
       ))
     ) eachGeth;

--- a/nixos/modules/services/computing/boinc/client.nix
+++ b/nixos/modules/services/computing/boinc/client.nix
@@ -99,10 +99,8 @@ in
       description = "BOINC Client";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      script = ''
-        exec ${fhsEnvExecutable} --dir ${cfg.dataDir} ${allowRemoteGuiRpcFlag}
-      '';
       serviceConfig = {
+        ExecStart = "${fhsEnvExecutable} --dir ${cfg.dataDir} ${allowRemoteGuiRpcFlag}";
         User = "boinc";
         Nice = 10;
       };

--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -475,15 +475,13 @@ in
             ''}
           '';
 
-          script = ''
-            export SLURM_CONF=${configPath}
-            exec ${cfg.package}/bin/slurmdbd -D
-          '';
+          environment.SLURM_CONF = configPath;
 
           serviceConfig = {
             RuntimeDirectory = "slurmdbd";
             Type = "simple";
             PIDFile = "/run/slurmdbd.pid";
+            ExecStart = "${lib.getExe' cfg.package "slurmdbd"} -D";
             ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
           };
         };

--- a/nixos/modules/services/hardware/pommed.nix
+++ b/nixos/modules/services/hardware/pommed.nix
@@ -51,7 +51,7 @@ in
     systemd.services.pommed = {
       description = "Pommed Apple Hotkeys Daemon";
       wantedBy = [ "multi-user.target" ];
-      script = "${pkgs.pommed_light}/bin/pommed -f";
+      serviceConfig.ExecStart = "${lib.getExe pkgs.pommed_light} -f";
     };
   };
 }

--- a/nixos/modules/services/home-automation/zigbee2mqtt.nix
+++ b/nixos/modules/services/home-automation/zigbee2mqtt.nix
@@ -79,6 +79,7 @@ in
       after = [ "network.target" ];
       environment.ZIGBEE2MQTT_DATA = cfg.dataDir;
       serviceConfig = {
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "cp"} --no-preserve=mode ${configFile} '${cfg.dataDir}/configuration.yaml'";
         ExecStart = "${cfg.package}/bin/zigbee2mqtt";
         User = "zigbee2mqtt";
         Group = "zigbee2mqtt";
@@ -129,9 +130,6 @@ in
         ];
         UMask = "0077";
       };
-      preStart = ''
-        cp --no-preserve=mode ${configFile} "${cfg.dataDir}/configuration.yaml"
-      '';
     };
 
     users.users.zigbee2mqtt = {

--- a/nixos/modules/services/logging/heartbeat.nix
+++ b/nixos/modules/services/logging/heartbeat.nix
@@ -67,12 +67,10 @@ in
     systemd.services.heartbeat = {
       description = "heartbeat log shipper";
       wantedBy = [ "multi-user.target" ];
-      preStart = ''
-        mkdir -p "${cfg.stateDir}"/{data,logs}
-      '';
       serviceConfig = {
         User = "nobody";
         AmbientCapabilities = "cap_net_raw";
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.stateDir}'/data '${cfg.stateDir}'/logs";
         ExecStart = "${cfg.package}/bin/heartbeat -c \"${heartbeatYml}\" -path.data \"${cfg.stateDir}/data\" -path.logs \"${cfg.stateDir}/logs\"";
       };
     };

--- a/nixos/modules/services/logging/journalbeat.nix
+++ b/nixos/modules/services/logging/journalbeat.nix
@@ -71,12 +71,12 @@ in
       wantedBy = [ "multi-user.target" ];
       wants = [ "elasticsearch.service" ];
       after = [ "elasticsearch.service" ];
-      preStart = ''
-        mkdir -p ${cfg.stateDir}/data
-        mkdir -p ${cfg.stateDir}/logs
-      '';
       serviceConfig = {
         StateDirectory = cfg.stateDir;
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.stateDir}/data"
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.stateDir}/logs"
+        ];
         ExecStart = ''
           ${cfg.package}/bin/journalbeat \
             -c ${journalbeatYml} \

--- a/nixos/modules/services/logging/journaldriver.nix
+++ b/nixos/modules/services/logging/journaldriver.nix
@@ -91,12 +91,12 @@ in
   config = mkIf cfg.enable {
     systemd.services.journaldriver = {
       description = "Stackdriver Logging journal forwarder";
-      script = "${pkgs.journaldriver}/bin/journaldriver";
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
+        ExecStart = lib.getExe pkgs.journaldriver;
         Restart = "always";
         DynamicUser = true;
 

--- a/nixos/modules/services/logging/promtail.nix
+++ b/nixos/modules/services/logging/promtail.nix
@@ -66,14 +66,11 @@ in
       wantedBy = [ "multi-user.target" ];
       stopIfChanged = false;
 
-      preStart = ''
-        ${lib.getExe pkgs.promtail} -config.file=${configFile} -check-syntax
-      '';
-
       serviceConfig = {
         Restart = "on-failure";
         TimeoutStopSec = 10;
 
+        ExecStartPre = "${lib.getExe pkgs.promtail} -config.file=${configFile} -check-syntax";
         ExecStart = "${pkgs.promtail}/bin/promtail -config.file=${configFile} ${escapeShellArgs cfg.extraFlags}";
 
         ProtectSystem = "strict";

--- a/nixos/modules/services/logging/syslog-ng.nix
+++ b/nixos/modules/services/logging/syslog-ng.nix
@@ -79,7 +79,6 @@ in
   config = lib.mkIf cfg.enable {
     systemd.services.syslog-ng = {
       description = "syslog-ng daemon";
-      preStart = "mkdir -p /{var,run}/syslog-ng";
       wantedBy = [ "multi-user.target" ];
       after = [ "multi-user.target" ]; # makes sure hostname etc is set
       serviceConfig = {
@@ -87,6 +86,7 @@ in
         PIDFile = pidFile;
         StandardOutput = "null";
         Restart = "on-failure";
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} -p /var/syslog-ng /run/syslog-ng";
         ExecStart = "${cfg.package}/sbin/syslog-ng ${lib.concatStringsSep " " syslogngOptions}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };

--- a/nixos/modules/services/mail/cyrus-imap.nix
+++ b/nixos/modules/services/mail/cyrus-imap.nix
@@ -342,6 +342,7 @@ in
         User = if (cfg.user == null) then "cyrus" else cfg.user;
         Group = if (cfg.group == null) then "cyrus" else cfg.group;
         Type = "simple";
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.imapdSettings.configdirectory}/socket' '${cfg.tmpDBDir}' /run/cyrus/proc /run/cyrus/lock";
         ExecStart = "${cyrus-imapdPkg}/libexec/master -l $LISTENQUEUE -C /etc/imapd.conf -M /etc/cyrus.conf -p /run/cyrus/master.pid -D";
         Restart = "on-failure";
         RestartSec = "1s";
@@ -367,9 +368,6 @@ in
         RestrictNamespaces = true;
         RestrictRealtime = true;
       };
-      preStart = ''
-        mkdir -p '${cfg.imapdSettings.configdirectory}/socket' '${cfg.tmpDBDir}' /run/cyrus/proc /run/cyrus/lock
-      '';
     };
     environment.systemPackages = [ cyrus-imapdPkg ];
   };

--- a/nixos/modules/services/mail/dkimproxy-out.nix
+++ b/nixos/modules/services/mail/dkimproxy-out.nix
@@ -109,10 +109,8 @@ in
             chown -R dkimproxy-out:dkimproxy-out "${keydir}"
           fi
         '';
-        script = ''
-          exec ${pkgs.dkimproxy}/bin/dkimproxy.out --conf_file=${configfile}
-        '';
         serviceConfig = {
+          ExecStart = "${pkgs.dkimproxy}/bin/dkimproxy.out --conf_file=${configfile}";
           User = "dkimproxy-out";
           PermissionsStartOnly = true;
         };

--- a/nixos/modules/services/mail/nullmailer.nix
+++ b/nixos/modules/services/mail/nullmailer.nix
@@ -245,13 +245,13 @@
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
 
-        preStart = ''
-          rm -f /var/spool/nullmailer/trigger && mkfifo -m 660 /var/spool/nullmailer/trigger
-        '';
-
         serviceConfig = {
           User = cfg.user;
           Group = cfg.group;
+          ExecStartPre = [
+            "${lib.getExe' pkgs.coreutils "rm"} -f /var/spool/nullmailer/trigger"
+            "${lib.getExe' pkgs.coreutils "mkfifo"} -m 660 /var/spool/nullmailer/trigger"
+          ];
           ExecStart = "${pkgs.nullmailer}/bin/nullmailer-send";
           Restart = "always";
         };

--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -210,13 +210,13 @@ in
         description = "Postfix Greylisting Service";
         wantedBy = [ "multi-user.target" ];
         before = [ "postfix.service" ];
-        preStart = ''
-          mkdir -p /var/postgrey
-          chown postgrey:postgrey /var/postgrey
-          chmod 0770 /var/postgrey
-        '';
         serviceConfig = {
           Type = "simple";
+          ExecStartPre = [
+            "${lib.getExe' pkgs.coreutils "mkdir"} -p /var/postgrey"
+            "${lib.getExe' pkgs.coreutils "chown"} postgrey:postgrey /var/postgrey"
+            "${lib.getExe' pkgs.coreutils "chmod"} 0770 /var/postgrey"
+          ];
           ExecStart = ''
             ${pkgs.postgrey}/bin/postgrey \
                       ${bind-flag} \

--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -162,17 +162,16 @@ in
           "network.target"
         ];
 
-        preStart =
-          if useLegacyStorage then
-            ''
-              mkdir -p ${cfg.dataDir}/data/blobs
-            ''
-          else
-            ''
-              mkdir -p ${cfg.dataDir}/db
-            '';
-
         serviceConfig = {
+          ExecStartPre =
+            if useLegacyStorage then
+              ''
+                ${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.dataDir}/data/blobs
+              ''
+            else
+              ''
+                ${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.dataDir}/db
+              '';
           ExecStart = [
             ""
             "${lib.getExe cfg.package} --config=${configFile}"

--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -1564,21 +1564,16 @@ in
           baseServiceConfig
           {
             description = "Synapse Matrix homeserver";
-            preStart = ''
-              ${cfg.package}/bin/synapse_homeserver \
-                --config-path ${configFile} \
-                --keys-directory ${cfg.dataDir} \
-                --generate-keys
-            '';
             serviceConfig = {
               ExecStartPre = [
-                (
-                  "+"
-                  + (pkgs.writeShellScript "matrix-synapse-fix-permissions" ''
-                    chown matrix-synapse:matrix-synapse ${cfg.settings.signing_key_path}
-                    chmod 0600 ${cfg.settings.signing_key_path}
-                  '')
-                )
+                ''
+                  ${cfg.package}/bin/synapse_homeserver \
+                    --config-path ${configFile} \
+                    --keys-directory ${cfg.dataDir} \
+                    --generate-keys
+                ''
+                "+${lib.getExe' pkgs.coreutils "chown"} matrix-synapse:matrix-synapse ${cfg.settings.signing_key_path}"
+                "+${lib.getExe' pkgs.coreutils "chmod"} 0600 ${cfg.settings.signing_key_path}"
               ];
               ExecStart = ''
                 ${cfg.package}/bin/synapse_homeserver \

--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -131,15 +131,15 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        # Install transcoders.
-        rm -rf ${cfg.home}/transcode
-        mkdir -p ${cfg.home}/transcode
-        for exe in ${toString cfg.transcoders}; do
-          ln -sf "$exe" ${cfg.home}/transcode
-        done
-      '';
       serviceConfig = {
+        # Install transcoders.
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "rm"} -rf '${cfg.home}/transcode'"
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.home}/transcode'"
+        ]
+        ++ map (
+          exe: "${lib.getExe' pkgs.coreutils "ln -sf '${exe}' '${cfg.home}/transcode'"}"
+        ) cfg.transcoders;
         ExecStart = ''
           ${cfg.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
           -Dairsonic.home=${cfg.home} \

--- a/nixos/modules/services/misc/autofs.nix
+++ b/nixos/modules/services/misc/autofs.nix
@@ -88,14 +88,11 @@ in
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        # There should be only one autofs service managed by systemd, so this should be safe.
-        rm -f /tmp/autofs-running
-      '';
-
       serviceConfig = {
         Type = "forking";
         PIDFile = "/run/autofs.pid";
+        # There should be only one autofs service managed by systemd, so this should be safe.
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "rm"} -f /tmp/autofs-running";
         ExecStart = "${pkgs.autofs5}/bin/automount ${lib.optionalString cfg.debug "-d"} -p /run/autofs.pid -t ${builtins.toString cfg.timeout} ${autoMaster}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };

--- a/nixos/modules/services/misc/bcg.nix
+++ b/nixos/modules/services/misc/bcg.nix
@@ -162,14 +162,12 @@ in
         ]
         ++ lib.optional config.services.mosquitto.enable "mosquitto.service";
         after = [ "network-online.target" ];
-        preStart = lib.mkIf envConfig ''
-          umask 077
-          ${pkgs.envsubst}/bin/envsubst -i "${configFile}" -o "${finalConfig}"
-        '';
         serviceConfig = {
           EnvironmentFile = cfg.environmentFiles;
+          ExecStartPre = lib.mkIf envConfig "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o \"${finalConfig}\"";
           ExecStart = "${cfg.package}/bin/bcg -c ${finalConfig} -v ${cfg.verbose}";
           RuntimeDirectory = "bcg";
+          RuntimeDirectoryMode = "0700";
         };
       };
   };

--- a/nixos/modules/services/misc/dictd.nix
+++ b/nixos/modules/services/misc/dictd.nix
@@ -78,7 +78,7 @@ in
         # with code 143 instead of exiting with code 0.
         serviceConfig.SuccessExitStatus = [ 143 ];
         serviceConfig.Type = "forking";
-        script = "${pkgs.dict}/sbin/dictd -s -c ${dictdb}/share/dictd/dictd.conf --locale en_US.UTF-8";
+        serviceConfig.ExecStart = "${pkgs.dict}/sbin/dictd -s -c ${dictdb}/share/dictd/dictd.conf --locale en_US.UTF-8";
       };
     };
 }

--- a/nixos/modules/services/misc/docker-registry.nix
+++ b/nixos/modules/services/misc/docker-registry.nix
@@ -143,11 +143,9 @@ in
       description = "Docker Container Registry";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      script = ''
-        ${cfg.package}/bin/registry serve ${configFile}
-      '';
 
       serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} serve ${configFile}";
         User = "docker-registry";
         WorkingDirectory = cfg.storagePath;
         AmbientCapabilities = lib.mkIf (cfg.port < 1024) "cap_net_bind_service";

--- a/nixos/modules/services/misc/errbot.nix
+++ b/nixos/modules/services/misc/errbot.nix
@@ -100,13 +100,13 @@ in
         {
           after = [ "network-online.target" ];
           wantedBy = [ "multi-user.target" ];
-          preStart = ''
-            mkdir -p ${dataDir}
-            chown -R errbot:errbot ${dataDir}
-          '';
           serviceConfig = {
             User = "errbot";
             Restart = "on-failure";
+            ExecStartPre = [
+              "${lib.getExe' pkgs.coreutils "mkdir"} -p ${dataDir}"
+              "${lib.getExe' pkgs.coreutils "chown"} -R errbot:errbot ${dataDir}"
+            ];
             ExecStart = "${pkgs.errbot}/bin/errbot -c ${mkConfigDir instanceCfg dataDir}/config.py";
             PermissionsStartOnly = true;
           };

--- a/nixos/modules/services/misc/gollum.nix
+++ b/nixos/modules/services/misc/gollum.nix
@@ -138,17 +138,13 @@ in
       description = "Gollum wiki";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.git ];
-
-      preStart = ''
-        # This is safe to be run on an existing repo
-        git init ${cfg.stateDir}
-      '';
 
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
         WorkingDirectory = cfg.stateDir;
+        # This is safe to be run on an existing repo
+        ExecStartPre = "${lib.getExe pkgs.git} init ${cfg.stateDir}";
         ExecStart = ''
           ${cfg.package}/bin/gollum \
             --port ${toString cfg.port} \

--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -284,21 +284,21 @@ in
         # should be sandboxed.
         systemd.services.guix-daemon = {
           environment = serviceEnv // config.networking.proxy.envVars;
-          script = ''
-            exec ${lib.getExe' package "guix-daemon"} \
-              --build-users-group=${cfg.group} \
-              ${
-                lib.optionalString (
-                  cfg.substituters.urls != [ ]
-                ) "--substitute-urls='${lib.concatStringsSep " " cfg.substituters.urls}'"
-              } \
-              ${lib.escapeShellArgs cfg.extraArgs}
-          '';
           serviceConfig = {
             OOMPolicy = "continue";
             RemainAfterExit = "yes";
             Restart = "always";
             TasksMax = 8192;
+            ExecStart = ''
+              ${lib.getExe' package "guix-daemon"} \
+                --build-users-group=${cfg.group} \
+                ${
+                  lib.optionalString (
+                    cfg.substituters.urls != [ ]
+                  ) "--substitute-urls='${lib.concatStringsSep " " cfg.substituters.urls}'"
+                } \
+                ${lib.escapeShellArgs cfg.extraArgs}
+            '';
           };
           unitConfig.RequiresMountsFor = [
             cfg.storeDir
@@ -407,15 +407,16 @@ in
                 ${lib.getExe' package "guix"} archive --generate-key;
               }
           '';
-          script = ''
-            exec ${lib.getExe' package "guix"} publish \
-              --user=${cfg.publish.user} --port=${builtins.toString cfg.publish.port} \
-              ${lib.escapeShellArgs cfg.publish.extraArgs}
-          '';
 
           serviceConfig = {
             Restart = "always";
             RestartSec = 10;
+
+            ExecStart = ''
+              ${lib.getExe' package "guix"} publish \
+                --user=${cfg.publish.user} --port=${builtins.toString cfg.publish.port} \
+                ${lib.escapeShellArgs cfg.publish.extraArgs}
+            '';
 
             ProtectClock = true;
             ProtectHostname = true;
@@ -463,11 +464,11 @@ in
         systemd.services.guix-gc = {
           description = "Guix garbage collection";
           startAt = cfg.gc.dates;
-          script = ''
-            exec ${lib.getExe' package "guix"} gc ${lib.escapeShellArgs cfg.gc.extraArgs}
-          '';
           serviceConfig = {
             Type = "oneshot";
+
+            ExecStart = "${lib.getExe' package "guix"} gc ${lib.escapeShellArgs cfg.gc.extraArgs}";
+
             PrivateDevices = true;
             PrivateNetwork = true;
             ProtectControlGroups = true;

--- a/nixos/modules/services/misc/mqtt2influxdb.nix
+++ b/nixos/modules/services/misc/mqtt2influxdb.nix
@@ -236,14 +236,12 @@ in
         description = "BigClown MQTT to InfluxDB bridge";
         wantedBy = [ "multi-user.target" ];
         wants = lib.mkIf config.services.mosquitto.enable [ "mosquitto.service" ];
-        preStart = ''
-          umask 077
-          ${pkgs.envsubst}/bin/envsubst -i "${configFile}" -o "${finalConfig}"
-        '';
         serviceConfig = {
           EnvironmentFile = cfg.environmentFiles;
+          ExecStartPre = lib.mkIf envConfig "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o \"${finalConfig}\"";
           ExecStart = "${lib.getExe cfg.package} -dc ${finalConfig}";
           RuntimeDirectory = "mqtt2influxdb";
+          RuntimeDirectoryMode = "0700";
         };
       };
   };

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -665,6 +665,9 @@ in
           serviceConfig = {
             User = cfg.user;
             WorkingDirectory = cfg.dataDir;
+            ExecStart = "${manage}/bin/paperless-manage document_exporter ${cfg.exporter.directory} ${
+              lib.cli.toCommandLineShellGNU { } cfg.exporter.settings
+            }";
           };
           unitConfig =
             let
@@ -683,13 +686,7 @@ in
               OnFailure = services;
               OnSuccess = services;
             };
-          enableStrictShellChecks = true;
           path = [ manage ];
-          script = ''
-            paperless-manage document_exporter ${cfg.exporter.directory} ${
-              lib.cli.toCommandLineShellGNU { } cfg.exporter.settings
-            }
-          '';
         };
       })
     ]

--- a/nixos/modules/services/misc/svnserve.nix
+++ b/nixos/modules/services/misc/svnserve.nix
@@ -40,8 +40,8 @@ in
     systemd.services.svnserve = {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      preStart = "mkdir -p ${cfg.svnBaseDir}";
-      script = "${pkgs.subversion.out}/bin/svnserve -r ${cfg.svnBaseDir} -d --foreground --pid-file=/run/svnserve.pid";
+      services.ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.svnBaseDir}";
+      services.ExecStart = "${pkgs.subversion.out}/bin/svnserve -r ${cfg.svnBaseDir} -d --foreground --pid-file=/run/svnserve.pid";
     };
   };
 }

--- a/nixos/modules/services/misc/tandoor-recipes.nix
+++ b/nixos/modules/services/misc/tandoor-recipes.nix
@@ -119,6 +119,12 @@ in
       after = lib.optional cfg.database.createLocally "postgresql.target";
 
       serviceConfig = {
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${manage} tandoor-recipes-manage"
+
+          # Let django migrate the DB as needed
+          "${lib.getExe pkg} migrate"
+        ];
         ExecStart = ''
           ${pkg.python.pkgs.gunicorn}/bin/gunicorn recipes.wsgi
         '';
@@ -171,13 +177,6 @@ in
       };
 
       wantedBy = [ "multi-user.target" ];
-
-      preStart = ''
-        ln -sf ${manage} tandoor-recipes-manage
-
-        # Let django migrate the DB as needed
-        ${pkg}/bin/tandoor-recipes migrate
-      '';
 
       environment = env // {
         PYTHONPATH = "${pkg.python.pkgs.makePythonPath pkg.propagatedBuildInputs}:${pkg}/lib/tandoor-recipes";

--- a/nixos/modules/services/misc/turn-rs.nix
+++ b/nixos/modules/services/misc/turn-rs.nix
@@ -68,16 +68,14 @@ in
       enable = true;
       wantedBy = [ "multi-user.target" ];
       description = "Turn-rs Server Daemon";
-      preStart =
-        let
-          configFile = format.generate "turn-rs-config.toml" cfg.settings;
-        in
-        ''
-          ${lib.getExe pkgs.envsubst} -i "${configFile}" -o /run/turn-rs/config.toml
-        '';
       serviceConfig = {
         RuntimeDirectory = "turn-rs";
         EnvironmentFile = lib.optional (cfg.secretFile != null) cfg.secretFile;
+        ExecStartPre =
+          let
+            configFile = format.generate "turn-rs-config.toml" cfg.settings;
+          in
+          "${lib.getExe pkgs.envsubst} -i '${configFile}' -o /run/turn-rs/config.toml";
         ExecStart = "${lib.getExe cfg.package} --config=/run/turn-rs/config.toml";
         DynamicUser = true;
       };

--- a/nixos/modules/services/misc/zookeeper.nix
+++ b/nixos/modules/services/misc/zookeeper.nix
@@ -142,13 +142,19 @@ in
 
     systemd.tmpfiles.rules = [
       "d '${cfg.dataDir}' 0700 zookeeper - - -"
+      "d '${cfg.dataDir}/version-2' 0700 zookeeper - - -"
+      "f '${cfg.dataDir}/myid' 0700 zookeeper - - ${toString cfg.id}"
       "Z '${cfg.dataDir}' 0700 zookeeper - - -"
     ];
 
     systemd.services.zookeeper = {
       description = "Zookeeper Daemon";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      requires = [ "systemd-tmpfiles-setup.service" ];
+      after = [
+        "systemd-tmpfiles-setup.service"
+        "network.target"
+      ];
       serviceConfig = {
         ExecStart = ''
           ${cfg.jre}/bin/java \
@@ -161,10 +167,6 @@ in
         '';
         User = "zookeeper";
       };
-      preStart = ''
-        echo "${toString cfg.id}" > ${cfg.dataDir}/myid
-        mkdir -p ${cfg.dataDir}/version-2
-      '';
     };
 
     users.users.zookeeper = {

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -2049,13 +2049,13 @@ in
       ]
       ++ lib.optional usePostgresql "postgresql.target"
       ++ lib.optional useMysql "mysql.service";
-      script = ''
-        set -o errexit -o pipefail -o nounset -o errtrace
-        shopt -s inherit_errexit
-
-        exec ${cfg.package}/bin/grafana server -homepath ${cfg.dataDir} -config ${configFile}
-      '';
       serviceConfig = {
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "ln"} -fs ${cfg.package}/share/grafana/conf ${cfg.dataDir}"
+          "${lib.getExe' pkgs.coreutils "ln"} -fs ${cfg.package}/share/grafana/tools ${cfg.dataDir}"
+        ];
+        ExecStart = "${cfg.package}/bin/grafana server -homepath ${cfg.dataDir} -config ${configFile}";
+
         WorkingDirectory = cfg.dataDir;
         User = "grafana";
         Restart = "on-failure";
@@ -2098,10 +2098,6 @@ in
         ++ lib.optionals (cfg.settings.server.protocol == "socket") [ "@chown" ];
         UMask = "0027";
       };
-      preStart = ''
-        ln -fs ${cfg.package}/share/grafana/conf ${cfg.dataDir}
-        ln -fs ${cfg.package}/share/grafana/tools ${cfg.dataDir}
-      '';
     };
 
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.settings.server.http_port ];

--- a/nixos/modules/services/monitoring/kthxbye.nix
+++ b/nixos/modules/services/monitoring/kthxbye.nix
@@ -137,23 +137,23 @@ in
     systemd.services.kthxbye = {
       description = "kthxbye Alertmanager ack management daemon";
       wantedBy = [ "multi-user.target" ];
-      script = ''
-        ${cfg.package}/bin/kthxbye \
-          -alertmanager.timeout ${cfg.alertmanager.timeout} \
-          -alertmanager.uri ${cfg.alertmanager.uri} \
-          -extend-by ${cfg.extendBy} \
-          -extend-if-expiring-in ${cfg.extendIfExpiringIn} \
-          -extend-with-prefix ${cfg.extendWithPrefix} \
-          -interval ${cfg.interval} \
-          -listen ${cfg.listenAddress}:${toString cfg.port} \
-          ${lib.optionalString cfg.logJSON "-log-json"} \
-          ${lib.optionalString (cfg.maxDuration != null) "-max-duration ${cfg.maxDuration}"} \
-          ${lib.concatStringsSep " " cfg.extraOptions}
-      '';
       serviceConfig = {
         Type = "simple";
         DynamicUser = true;
         Restart = "on-failure";
+        ExecStart = ''
+          ${cfg.package}/bin/kthxbye \
+            -alertmanager.timeout ${cfg.alertmanager.timeout} \
+            -alertmanager.uri ${cfg.alertmanager.uri} \
+            -extend-by ${cfg.extendBy} \
+            -extend-if-expiring-in ${cfg.extendIfExpiringIn} \
+            -extend-with-prefix ${cfg.extendWithPrefix} \
+            -interval ${cfg.interval} \
+            -listen ${cfg.listenAddress}:${toString cfg.port} \
+            ${lib.optionalString cfg.logJSON "-log-json"} \
+            ${lib.optionalString (cfg.maxDuration != null) "-max-duration ${cfg.maxDuration}"} \
+            ${lib.concatStringsSep " " cfg.extraOptions}
+        '';
       };
     };
 

--- a/nixos/modules/services/monitoring/prometheus/alertmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager.nix
@@ -200,11 +200,8 @@ in
         wantedBy = [ "multi-user.target" ];
         wants = [ "network-online.target" ];
         after = [ "network-online.target" ];
-        preStart = ''
-          ${lib.getBin pkgs.envsubst}/bin/envsubst -o "/tmp/alert-manager-substituted.yaml" \
-                                                   -i "${alertmanagerYml}"
-        '';
         serviceConfig = {
+          ExecStartPre = "${lib.getBin pkgs.envsubst}/bin/envsubst -i '${alertmanagerYml}' -o '/tmp/alert-manager-substituted.yaml'";
           ExecStart =
             "${cfg.package}/bin/alertmanager"
             + lib.optionalString (lib.length cmdlineArgs != 0) (

--- a/nixos/modules/services/monitoring/prometheus/exporters/junos-czerwonk.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/junos-czerwonk.nix
@@ -68,12 +68,8 @@ in
       DynamicUser = false;
       EnvironmentFile = mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
       RuntimeDirectory = "prometheus-junos-czerwonk-exporter";
-      ExecStartPre = [
-        "${pkgs.writeShellScript "subst-secrets-junos-czerwonk-exporter" ''
-          umask 0077
-          ${pkgs.envsubst}/bin/envsubst -i ${configFile} -o ''${RUNTIME_DIRECTORY}/junos-exporter.json
-        ''}"
-      ];
+      RuntimeDirectoryMode = "0700";
+      ExecStartPre = "${pkgs.envsubst}/bin/envsubst -i ${configFile} -o %t/junos-exporter.json";
       ExecStart = ''
         ${pkgs.prometheus-junos-czerwonk-exporter}/bin/junos_exporter \
           -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \

--- a/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
@@ -199,11 +199,9 @@ in
       DynamicUser = false;
       EnvironmentFile = mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
       RuntimeDirectory = "prometheus-mail-exporter";
+      RuntimeDirectoryMode = "0700";
       ExecStartPre = [
-        "${pkgs.writeShellScript "subst-secrets-mail-exporter" ''
-          umask 0077
-          ${pkgs.envsubst}/bin/envsubst -i ${configFile} -o ''${RUNTIME_DIRECTORY}/mail-exporter.json
-        ''}"
+        "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o '%t/mail-exporter.json'"
       ];
       ExecStart = ''
         ${pkgs.prometheus-mail-exporter}/bin/mailexporter \

--- a/nixos/modules/services/monitoring/prometheus/exporters/pgbouncer.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/pgbouncer.nix
@@ -139,9 +139,9 @@ in
 
   serviceOpts = {
     after = [ "pgbouncer.service" ];
-    script = concatStringsSep " " (
+    serviceConfig.ExecStart = concatStringsSep " " (
       [
-        "exec -- ${escapeShellArg (getExe cfg.package)}"
+        "${escapeShellArg (getExe cfg.package)}"
         "--web.listen-address ${cfg.listenAddress}:${toString cfg.port}"
       ]
       ++ optionals (cfg.connectionString != null) [

--- a/nixos/modules/services/monitoring/prometheus/sachet.nix
+++ b/nixos/modules/services/monitoring/prometheus/sachet.nix
@@ -70,13 +70,12 @@ in
         "network.target"
         "network-online.target"
       ];
-      script = ''
-        ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /tmp/sachet.yaml
-        exec ${pkgs.prometheus-sachet}/bin/sachet -config /tmp/sachet.yaml -listen-address ${cfg.address}:${builtins.toString cfg.port}
-      '';
 
       serviceConfig = {
         Restart = "always";
+
+        ExecStartPre = "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o /tmp/sachet.yaml";
+        ExecStart = "${pkgs.prometheus-sachet}/bin/sachet -config /tmp/sachet.yaml -listen-address ${cfg.address}:${builtins.toString cfg.port}";
 
         ProtectSystem = "strict";
         ProtectHome = true;

--- a/nixos/modules/services/monitoring/telegraf.nix
+++ b/nixos/modules/services/monitoring/telegraf.nix
@@ -73,14 +73,12 @@ in
         serviceConfig = {
           EnvironmentFile = config.services.telegraf.environmentFiles;
           ExecStartPre = lib.optional (config.services.telegraf.environmentFiles != [ ]) (
-            pkgs.writeShellScript "pre-start" ''
-              umask 077
-              ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /var/run/telegraf/config.toml
-            ''
+            "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o /var/run/telegraf/config.toml"
           );
           ExecStart = "${cfg.package}/bin/telegraf -config ${finalConfigFile}";
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
           RuntimeDirectory = "telegraf";
+          RuntimeDirectoryMode = "0700";
           User = "telegraf";
           Group = "telegraf";
           Restart = "on-failure";

--- a/nixos/modules/services/network-filesystems/openafs/server.nix
+++ b/nixos/modules/services/network-filesystems/openafs/server.nix
@@ -333,12 +333,16 @@ in
         unitConfig.ConditionPathExists = [
           "|/etc/openafs/server/KeyFileExt"
         ];
-        preStart = ''
-          mkdir -m 0755 -p /var/openafs
-          ${optionalString (netInfo != null) "cp ${netInfo} /var/openafs/netInfo"}
-          ${optionalString useBuCellServDB "cp ${buCellServDB}"}
-        '';
         serviceConfig = {
+          ExecStartPre = [
+            "${lib.getExe' pkgs.coreutils "mkdir"} -m 0755 -p /var/openafs"
+          ]
+          ++ lib.optionals (netInfo != null) [
+            "${lib.getExe' pkgs.coreutils "cp"} ${netInfo} /var/openafs/netInfo"
+          ]
+          ++ lib.optionals useBuCellServDB [
+            "${lib.getExe' pkgs.coreutils "cp"} ${buCellServDB}"
+          ];
           ExecStart = "${openafsBin}/bin/bosserver -nofork";
           ExecStop = "${openafsBin}/bin/bos shutdown localhost -wait -localauth";
         };

--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -108,17 +108,16 @@ in
         daemontools
         djbdns
       ];
+      environment.FORWARDONLY = lib.mkIf cfg.forwardOnly "1";
       preStart = ''
         rm -rf /var/lib/dnscache
         dnscache-conf dnscache dnscache /var/lib/dnscache ${config.services.dnscache.ip}
         rm -rf /var/lib/dnscache/root
         ln -sf ${dnscache-root} /var/lib/dnscache/root
       '';
-      script = ''
-        cd /var/lib/dnscache/
-        ${lib.optionalString cfg.forwardOnly "export FORWARDONLY=1"}
-        exec ./run
-      '';
+      serviceConfig.StateDirectory = "dnscache";
+      serviceConfig.WorkingDirectory = "/var/lib/dnscache";
+      serviceConfig.ExecStart = "/var/lib/dnscache/run";
     };
   };
 }

--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -109,14 +109,14 @@ in
         djbdns
       ];
       environment.FORWARDONLY = lib.mkIf cfg.forwardOnly "1";
-      preStart = ''
-        rm -rf /var/lib/dnscache
-        dnscache-conf dnscache dnscache /var/lib/dnscache ${config.services.dnscache.ip}
-        rm -rf /var/lib/dnscache/root
-        ln -sf ${dnscache-root} /var/lib/dnscache/root
-      '';
       serviceConfig.StateDirectory = "dnscache";
       serviceConfig.WorkingDirectory = "/var/lib/dnscache";
+      serviceConfig.ExecStartPre = [
+        "${lib.getExe' pkgs.coreutils "rm"} -rf /var/lib/dnscache"
+        "${lib.getExe' djbdns "dnscache-conf"} dnscache dnscache /var/lib/dnscache ${config.services.dnscache.ip}"
+        "${lib.getExe' pkgs.coreutils "rm"} -rf /var/lib/dnscache/root"
+        "${lib.getExe' pkgs.coreutils "ln"} -sf ${dnscache-root} /var/lib/dnscache/root"
+      ];
       serviceConfig.ExecStart = "/var/lib/dnscache/run";
     };
   };

--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -113,7 +113,7 @@ in
       serviceConfig.WorkingDirectory = "/var/lib/dnscache";
       serviceConfig.ExecStartPre = [
         "${lib.getExe' pkgs.coreutils "rm"} -rf /var/lib/dnscache"
-        "${lib.getExe' djbdns "dnscache-conf"} dnscache dnscache /var/lib/dnscache ${config.services.dnscache.ip}"
+        "${lib.getExe' pkgs.djbdns "dnscache-conf"} dnscache dnscache /var/lib/dnscache ${config.services.dnscache.ip}"
         "${lib.getExe' pkgs.coreutils "rm"} -rf /var/lib/dnscache/root"
         "${lib.getExe' pkgs.coreutils "ln"} -sf ${dnscache-root} /var/lib/dnscache/root"
       ];

--- a/nixos/modules/services/networking/freeradius.nix
+++ b/nixos/modules/services/networking/freeradius.nix
@@ -13,11 +13,9 @@ let
     wantedBy = [ "multi-user.target" ];
     after = [ "network.target" ];
     wants = [ "network.target" ];
-    preStart = ''
-      ${cfg.package}/bin/radiusd -C -d ${cfg.configDir} -l stdout
-    '';
 
     serviceConfig = {
+      ExecStartPre = "${cfg.package}/bin/radiusd -C -d ${cfg.configDir} -l stdout";
       ExecStart =
         "${cfg.package}/bin/radiusd -f -d ${cfg.configDir} -l stdout" + lib.optionalString cfg.debug " -xx";
       ExecReload = [

--- a/nixos/modules/services/networking/ghostunnel.nix
+++ b/nixos/modules/services/networking/ghostunnel.nix
@@ -194,27 +194,28 @@ let
               ++ optional (config.cert != null) "cert:${config.cert}"
               ++ optional (config.key != null) "key:${config.key}"
               ++ optional (config.cacert != null) "cacert:${config.cacert}";
+
+            ExecStart = concatStringsSep " " (
+              [ "${mainCfg.package}/bin/ghostunnel" ]
+              ++ optional (config.keystore != null) "--keystore=$CREDENTIALS_DIRECTORY/keystore"
+              ++ optional (config.cert != null) "--cert=$CREDENTIALS_DIRECTORY/cert"
+              ++ optional (config.key != null) "--key=$CREDENTIALS_DIRECTORY/key"
+              ++ optional (config.cacert != null) "--cacert=$CREDENTIALS_DIRECTORY/cacert"
+              ++ [
+                "server"
+                "--listen ${config.listen}"
+                "--target ${config.target}"
+              ]
+              ++ optional config.allowAll "--allow-all"
+              ++ map (v: "--allow-cn=${escapeShellArg v}") config.allowCN
+              ++ map (v: "--allow-ou=${escapeShellArg v}") config.allowOU
+              ++ map (v: "--allow-dns=${escapeShellArg v}") config.allowDNS
+              ++ map (v: "--allow-uri=${escapeShellArg v}") config.allowURI
+              ++ optional config.disableAuthentication "--disable-authentication"
+              ++ optional config.unsafeTarget "--unsafe-target"
+              ++ [ config.extraArguments ]
+            );
           };
-          script = concatStringsSep " " (
-            [ "${mainCfg.package}/bin/ghostunnel" ]
-            ++ optional (config.keystore != null) "--keystore=$CREDENTIALS_DIRECTORY/keystore"
-            ++ optional (config.cert != null) "--cert=$CREDENTIALS_DIRECTORY/cert"
-            ++ optional (config.key != null) "--key=$CREDENTIALS_DIRECTORY/key"
-            ++ optional (config.cacert != null) "--cacert=$CREDENTIALS_DIRECTORY/cacert"
-            ++ [
-              "server"
-              "--listen ${config.listen}"
-              "--target ${config.target}"
-            ]
-            ++ optional config.allowAll "--allow-all"
-            ++ map (v: "--allow-cn=${escapeShellArg v}") config.allowCN
-            ++ map (v: "--allow-ou=${escapeShellArg v}") config.allowOU
-            ++ map (v: "--allow-dns=${escapeShellArg v}") config.allowDNS
-            ++ map (v: "--allow-uri=${escapeShellArg v}") config.allowURI
-            ++ optional config.disableAuthentication "--disable-authentication"
-            ++ optional config.unsafeTarget "--unsafe-target"
-            ++ [ config.extraArguments ]
-          );
         };
       };
     };

--- a/nixos/modules/services/networking/ircd-hybrid/default.nix
+++ b/nixos/modules/services/networking/ircd-hybrid/default.nix
@@ -152,7 +152,7 @@ in
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
-      script = "${ircdService}/bin/control start";
+      serviceConfig.ExecStart = "${ircdService}/bin/control start";
     };
   };
 }

--- a/nixos/modules/services/networking/keepalived/default.nix
+++ b/nixos/modules/services/networking/keepalived/default.nix
@@ -369,12 +369,10 @@ in
           PIDFile = pidFile;
           KillMode = "process";
           RuntimeDirectory = "keepalived";
+          RuntimeDirectoryMode = "0700";
           EnvironmentFile = lib.optional (cfg.secretFile != null) cfg.secretFile;
           ExecStartPre = lib.optional (cfg.secretFile != null) (
-            pkgs.writeShellScript "keepalived-pre-start" ''
-              umask 077
-              ${pkgs.envsubst}/bin/envsubst -i "${keepalivedConf}" > ${finalConfigFile}
-            ''
+            "${pkgs.envsubst}/bin/envsubst -i '${keepalivedConf}' -o '${finalConfigFile}'"
           );
           ExecStart =
             "${lib.getExe cfg.package}"

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -320,17 +320,13 @@ in
       description = "Murmur Chat Service";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      preStart = ''
-        ${pkgs.envsubst}/bin/envsubst \
-          -o /run/murmur/murmurd.ini \
-          -i ${configFile}
-      '';
 
       serviceConfig = {
         # murmurd doesn't fork when logging to the console.
         Type = if forking then "forking" else "simple";
         PIDFile = lib.mkIf forking "/run/murmur/murmurd.pid";
         EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        ExecStartPre = "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o /run/murmur/murmurd.ini";
         ExecStart = "${cfg.package}/bin/mumble-server -ini /run/murmur/murmurd.ini";
         Restart = "always";
         LogsDirectory = lib.mkIf cfg.logToFile "murmur";

--- a/nixos/modules/services/networking/ncps.nix
+++ b/nixos/modules/services/networking/ncps.nix
@@ -275,12 +275,9 @@ in
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        ${lib.getExe cfg.dbmatePackage} --migrations-dir=${cfg.package}/share/ncps/db/migrations --url=${cfg.cache.databaseURL} up
-      '';
-
       serviceConfig = lib.mkMerge [
         {
+          ExecStartPre = "${lib.getExe cfg.dbmatePackage} --migrations-dir=${cfg.package}/share/ncps/db/migrations --url=${cfg.cache.databaseURL} up";
           ExecStart = "${lib.getExe cfg.package} ${globalFlags} serve ${serveFlags}";
           User = "ncps";
           Group = "ncps";

--- a/nixos/modules/services/networking/ncps.nix
+++ b/nixos/modules/services/networking/ncps.nix
@@ -239,40 +239,32 @@ in
     };
     users.groups.ncps = { };
 
-    systemd.services.ncps-create-directories = {
-      description = "Created required directories by ncps";
-      serviceConfig = {
-        Type = "oneshot";
-        UMask = "0066";
+    systemd.tmpfiles.settings."10-ncps" = {
+      ${cfg.cache.dataPath}.d = lib.mkIf (cfg.cache.dataPath != "/var/lib/ncps") {
+        user = "ncps";
+        group = "ncps";
       };
-      script =
-        (lib.optionalString (cfg.cache.dataPath != "/var/lib/ncps") ''
-          if ! test -d ${cfg.cache.dataPath}; then
-            mkdir -p ${cfg.cache.dataPath}
-            chown ncps:ncps ${cfg.cache.dataPath}
-          fi
-        '')
-        + (lib.optionalString isSqlite ''
-          if ! test -d ${dbDir}; then
-            mkdir -p ${dbDir}
-            chown ncps:ncps ${dbDir}
-          fi
-        '')
-        + (lib.optionalString (cfg.cache.tempPath != "/tmp") ''
-          if ! test -d ${cfg.cache.tempPath}; then
-            mkdir -p ${cfg.cache.tempPath}
-            chown ncps:ncps ${cfg.cache.tempPath}
-          fi
-        '');
-      wantedBy = [ "ncps.service" ];
-      before = [ "ncps.service" ];
+      ${dbDir}.d = lib.mkIf isSqlite {
+        user = "ncps";
+        group = "ncps";
+      };
+      ${cfg.cache.tempPath}.d = lib.mkIf (cfg.cache.tempPath != "/tmp") {
+        user = "ncps";
+        group = "ncps";
+      };
     };
 
     systemd.services.ncps = {
       description = "ncps binary cache proxy service";
 
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+        "systemd-tmpfiles-setup.service"
+      ];
+      wants = [
+        "network-online.target"
+        "systemd-tmpfiles-setup.service"
+      ];
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = lib.mkMerge [

--- a/nixos/modules/services/networking/nghttpx/default.nix
+++ b/nixos/modules/services/networking/nghttpx/default.nix
@@ -115,11 +115,9 @@ in
       nghttpx = {
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
-        script = ''
-          ${pkgs.nghttp2}/bin/nghttpx --conf=${configurationFile}
-        '';
 
         serviceConfig = {
+          ExecStart = "${pkgs.nghttp2}/bin/nghttpx --conf=${configurationFile}";
           Restart = "on-failure";
           RestartSec = 60;
         };

--- a/nixos/modules/services/networking/nm-file-secret-agent.nix
+++ b/nixos/modules/services/networking/nm-file-secret-agent.nix
@@ -125,7 +125,7 @@ in
       after = [ "NetworkManager.service" ];
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ nmFileSecretAgentConfigFile ];
-      script = "${lib.getExe cfg.ensureProfiles.secrets.package} --conf ${nmFileSecretAgentConfigFile}";
+      serviceConfig.ExecStart = "${lib.getExe cfg.ensureProfiles.secrets.package} --conf ${nmFileSecretAgentConfigFile}";
     };
   };
 }

--- a/nixos/modules/services/networking/oidentd.nix
+++ b/nixos/modules/services/networking/oidentd.nix
@@ -32,7 +32,7 @@ with lib;
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig.Type = "forking";
-      script = "${pkgs.oidentd}/sbin/oidentd -u oidentd -g nogroup";
+      serviceConfig.ExecStart = "${lib.getExe pkgs.oidentd} -u oidentd -g nogroup";
     };
 
     users.users.oidentd = {

--- a/nixos/modules/services/networking/opengfw.nix
+++ b/nixos/modules/services/networking/opengfw.nix
@@ -374,21 +374,22 @@ in
         after = [ "network.target" ];
         path = with pkgs; [ iptables ];
 
-        preStart = ''
-          ${optionalString (rules != null) "ln -sf ${rules} rules.yaml"}
-          ${optionalString (settings != null) "ln -sf ${settings} config.yaml"}
-        '';
-
-        script = ''
-          ${config.security.wrapperDir}/OpenGFW \
-            -f ${cfg.logFormat} \
-            -l ${cfg.logLevel} \
-            ${optionalString (cfg.pcapReplay != null) "-p ${cfg.pcapReplay}"} \
-            -c config.yaml \
-            rules.yaml
-        '';
-
         serviceConfig = rec {
+          ExecStartPre =
+            lib.optionals (rules != null) [ "${lib.getExe' pkgs.coreutils "ln"} -sf ${rules} rules.yaml" ]
+            ++ lib.optionals (settings != null) [
+              "${lib.getExe' pkgs.coreutils "ln"} -sf ${settings} config.yaml"
+            ];
+          ExecStart =
+            let
+              args = lib.cli.toCommandLineShellGNU { } {
+                f = cfg.logFormat;
+                l = cfg.logLevel;
+                p = cfg.pcapReplay;
+                c = "config.yaml";
+              };
+            in
+            "${config.security.wrapperDir}/OpenGFW ${args} rules.yaml";
           WorkingDirectory = cfg.dir;
           ExecReload = "${lib.getExe' pkgs.coreutils "kill"} -HUP $MAINPID";
           Restart = "always";

--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -83,11 +83,14 @@ let
   restartService = optionalAttrs cfg.restartAfterSleep {
     openvpn-restart = {
       wantedBy = [ "sleep.target" ];
-      script =
-        let
-          unitNames = map (n: "openvpn-${n}.service") (builtins.attrNames cfg.servers);
-        in
-        "systemctl try-restart ${lib.escapeShellArgs unitNames}";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart =
+          let
+            unitNames = map (n: "openvpn-${n}.service") (builtins.attrNames cfg.servers);
+          in
+          "systemctl try-restart ${lib.escapeShellArgs unitNames}";
+      };
       description = "Restart system OpenVPN connections when returning from sleep";
     };
   };

--- a/nixos/modules/services/networking/ostinato.nix
+++ b/nixos/modules/services/networking/ostinato.nix
@@ -108,9 +108,7 @@ in
     systemd.services.drone = {
       description = "Ostinato agent-controller";
       wantedBy = [ "multi-user.target" ];
-      script = ''
-        ${pkg}/bin/drone ${toString cfg.port} ${configFile}
-      '';
+      serviceConfig.ExecStart = "${pkg}/bin/drone ${toString cfg.port} ${configFile}";
     };
 
   };

--- a/nixos/modules/services/networking/pangolin.nix
+++ b/nixos/modules/services/networking/pangolin.nix
@@ -241,11 +241,6 @@ in
           requires = [ "network.target" ];
           after = [ "network.target" ];
 
-          preStart = ''
-            mkdir -p ${cfg.dataDir}/config
-            cp -f ${cfgFile} ${cfg.dataDir}/config/config.yml
-          '';
-
           serviceConfig = {
             User = "pangolin";
             Group = "fossorial";
@@ -316,6 +311,11 @@ in
               "~@setuid:EPERM"
               "~@swap:EPERM"
               "~@timer:EPERM"
+            ];
+
+            ExecStartPre = [
+              "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.dataDir}/config"
+              "${lib.getExe' pkgs.coreutils "cp"} -f ${cfgFile} ${cfg.dataDir}/config/config.yml"
             ];
             ExecStart = lib.getExe cfg.package;
           };

--- a/nixos/modules/services/networking/pdnsd.nix
+++ b/nixos/modules/services/networking/pdnsd.nix
@@ -80,13 +80,13 @@ in
     systemd.services.pdnsd = {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      preStart = ''
-        mkdir -p "${cfg.cacheDir}"
-        touch "${cfg.cacheDir}/pdnsd.cache"
-        chown -R ${pdnsdUser}:${pdnsdGroup} "${cfg.cacheDir}"
-      '';
       description = "pdnsd";
       serviceConfig = {
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.cacheDir}'"
+          "${lib.getExe' pkgs.coreutils "touch"} '${cfg.cacheDir}/pdnsd.cache'"
+          "${lib.getExe' pkgs.coreutils "chown"} -R ${pdnsdUser}:${pdnsdGroup} '${cfg.cacheDir}'"
+        ];
         ExecStart = "${pdnsd}/bin/pdnsd -c ${pdnsdConf}";
       };
     };

--- a/nixos/modules/services/networking/powerdns.nix
+++ b/nixos/modules/services/networking/powerdns.nix
@@ -59,11 +59,9 @@ in
 
       serviceConfig = {
         EnvironmentFile = lib.optional (cfg.secretFile != null) cfg.secretFile;
+        RuntimeDirectoryMode = "0700";
         ExecStartPre = lib.optional (cfg.secretFile != null) (
-          pkgs.writeShellScript "pdns-pre-start" ''
-            umask 077
-            ${pkgs.envsubst}/bin/envsubst -i "${configDir}/pdns.conf" > ${finalConfigDir}/pdns.conf
-          ''
+          "${pkgs.envsubst}/bin/envsubst -i '${configDir}/pdns.conf' -o '${finalConfigDir}/pdns.conf'"
         );
         ExecStart = [
           ""

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -978,11 +978,6 @@ in
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ config.environment.etc."prosody/prosody.cfg.lua".source ];
-      preStart = ''
-        ${pkgs.envsubst}/bin/envsubst -i ${
-          config.environment.etc."prosody/prosody.cfg.lua".source
-        } -o /run/prosody/prosody.cfg.lua
-      '';
       serviceConfig = mkMerge [
         {
           User = cfg.user;
@@ -991,6 +986,7 @@ in
           RuntimeDirectory = "prosody";
           PIDFile = "/run/prosody/prosody.pid";
           Environment = "PROSODY_CONFIG=/run/prosody/prosody.cfg.lua";
+          ExecStartPre = "${pkgs.envsubst}/bin/envsubst -i /etc/prosody/prosody.cfg.lua -o /run/prosody/prosody.cfg.lua";
           ExecStart = "${lib.getExe cfg.package} -F";
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
           Restart = "on-abnormal";

--- a/nixos/modules/services/networking/redsocks.nix
+++ b/nixos/modules/services/networking/redsocks.nix
@@ -276,7 +276,7 @@ in
         description = "Redsocks";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
-        script = "${pkgs.redsocks}/bin/redsocks -c ${configfile}";
+        serviceConfig.ExecStart = "${lib.getExe pkgs.redsocks} -c ${configfile}";
       };
 
       networking.firewall.extraCommands = iptables;

--- a/nixos/modules/services/networking/rosenpass.nix
+++ b/nixos/modules/services/networking/rosenpass.nix
@@ -235,15 +235,12 @@ in
             "pqsk:${cfg.settings.secret_key}"
             "pqpk:${cfg.settings.public_key}"
           ];
+          ExecStartPre = "${getExe pkgs.envsubst} -i '${config}' -o \"$CONFIG\"";
+          ExecStart = "${lib.getExe cfg.package} exchange-config \"$CONFIG\"";
         };
 
         # See <https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers>
         environment.CONFIG = "%t/${serviceConfig.RuntimeDirectory}/config.toml";
-
-        script = ''
-          ${getExe pkgs.envsubst} -i ${config} -o "$CONFIG"
-          rosenpass exchange-config "$CONFIG"
-        '';
       };
   };
 }

--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -337,12 +337,12 @@ in
       serviceConfig = {
         User = cfg.user;
         Restart = "on-failure";
+        ExecStartPre = [
+          "${cfg.package}/bin/smokeping --check --config=${configPath}"
+          "${cfg.package}/bin/smokeping --static --config=${configPath}"
+        ];
         ExecStart = "${cfg.package}/bin/smokeping --config=/etc/smokeping.conf --nodaemon";
       };
-      preStart = ''
-        ${cfg.package}/bin/smokeping --check --config=${configPath}
-        ${cfg.package}/bin/smokeping --static --config=${configPath}
-      '';
     };
 
     systemd.tmpfiles.rules = [

--- a/nixos/modules/services/networking/supybot.nix
+++ b/nixos/modules/services/networking/supybot.nix
@@ -104,14 +104,12 @@ in
       documentation = [ "https://limnoria.readthedocs.io/" ];
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      preStart = ''
-        # This needs to be created afresh every time
-        rm -f '${cfg.stateDir}/supybot.cfg.bak'
-      '';
 
       startLimitIntervalSec = 5 * 60; # 5 min
       startLimitBurst = 1;
       serviceConfig = {
+        # This needs to be created afresh every time
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "rm"} -f '${cfg.stateDir}/supybot.cfg.bak'";
         ExecStart = "${pyEnv}/bin/supybot ${cfg.stateDir}/supybot.cfg";
         PIDFile = "/run/supybot.pid";
         User = "supybot";

--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -243,10 +243,8 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         Type = "oneshot";
+        ExecStart = "${lib.getExe cfg.package} set ${escapeShellArgs cfg.extraSetFlags}";
       };
-      script = ''
-        ${lib.getExe cfg.package} set ${escapeShellArgs cfg.extraSetFlags}
-      '';
     };
 
     boot.kernel.sysctl = mkIf (cfg.useRoutingFeatures == "server" || cfg.useRoutingFeatures == "both") {

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -112,11 +112,11 @@ in
     systemd.services.thelounge = {
       description = "The Lounge web IRC client";
       wantedBy = [ "multi-user.target" ];
-      preStart = "ln -sf ${pkgs.writeText "config.js" configJsData} ${dataDir}/config.js";
       environment.THELOUNGE_PACKAGES = mkIf (cfg.plugins != [ ]) "${plugins}";
       serviceConfig = {
         User = "thelounge";
         StateDirectory = baseNameOf dataDir;
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "ln"} -sf ${pkgs.writeText "config.js" configJsData} ${dataDir}/config.js";
         ExecStart = "${getExe cfg.package} start";
       };
     };

--- a/nixos/modules/services/networking/tinydns.nix
+++ b/nixos/modules/services/networking/tinydns.nix
@@ -58,10 +58,11 @@ with lib;
         ln -sf ${pkgs.writeText "tinydns-data" config.services.tinydns.data} data
         tinydns-data
       '';
-      script = ''
-        cd /var/lib/tinydns
-        exec ./run
-      '';
+      serviceConfig = {
+        StateDirectory = "tinydns";
+        WorkingDirectory = "/var/lib/tinydns";
+        ExecStart = "/var/lib/tinydns/run";
+      };
     };
   };
 }

--- a/nixos/modules/services/networking/toxvpn.nix
+++ b/nixos/modules/services/networking/toxvpn.nix
@@ -43,20 +43,19 @@ with lib;
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
 
-      preStart = ''
-        mkdir -p /run/toxvpn || true
-        chown toxvpn /run/toxvpn
-      '';
-
-      path = [ pkgs.toxvpn ];
-
-      script = ''
-        exec toxvpn -i ${config.services.toxvpn.localip} -l /run/toxvpn/control -u toxvpn -p ${toString config.services.toxvpn.port} ${
-          lib.concatMapStringsSep " " (x: "-a ${x}") config.services.toxvpn.auto_add_peers
-        }
-      '';
-
       serviceConfig = {
+        ExecStart =
+          let
+            args = lib.cli.toCommandLineShellGNU { } {
+              i = config.services.toxvpn.localip;
+              l = "/run/toxvpn/control";
+              u = "toxvpn";
+              p = config.services.toxvpn.port;
+              a = config.services.toxvpn.auto_add_peers;
+            };
+          in
+          "${lib.getExe pkgs.toxvpn} ${args}";
+        RuntimeDirectory = "toxvpn";
         KillMode = "process";
         Restart = "on-success";
         Type = "notify";

--- a/nixos/modules/services/networking/twingate.nix
+++ b/nixos/modules/services/networking/twingate.nix
@@ -17,7 +17,7 @@ in
   config = lib.mkIf cfg.enable {
     systemd.packages = [ cfg.package ];
     systemd.services.twingate = {
-      preStart = "cp -r --update=none ${cfg.package}/etc/twingate/. /etc/twingate/";
+      serviceConfig.ExecStartPre = "${lib.getExe' pkgs.coreutils "cp"} -r --update=none ${cfg.package}/etc/twingate/. /etc/twingate/";
       wantedBy = [ "multi-user.target" ];
     };
 

--- a/nixos/modules/services/networking/webhook.nix
+++ b/nixos/modules/services/networking/webhook.nix
@@ -208,31 +208,31 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       environment = config.networking.proxy.envVars // cfg.environment;
-      script =
-        let
-          args = [
-            "-ip"
-            cfg.ip
-            "-port"
-            (toString cfg.port)
-            "-urlprefix"
-            cfg.urlPrefix
-          ]
-          ++ concatMap (hook: [
-            "-hooks"
-            hook
-          ]) hookFiles
-          ++ optional cfg.enableTemplates "-template"
-          ++ optional cfg.verbose "-verbose"
-          ++ cfg.extraArgs;
-        in
-        ''
-          ${cfg.package}/bin/webhook ${escapeShellArgs args}
-        '';
       serviceConfig = {
         Restart = "on-failure";
         User = cfg.user;
         Group = cfg.group;
+        ExecStart =
+          let
+            args = [
+              "-ip"
+              cfg.ip
+              "-port"
+              (toString cfg.port)
+              "-urlprefix"
+              cfg.urlPrefix
+            ]
+            ++ concatMap (hook: [
+              "-hooks"
+              hook
+            ]) hookFiles
+            ++ optional cfg.enableTemplates "-template"
+            ++ optional cfg.verbose "-verbose"
+            ++ cfg.extraArgs;
+          in
+          ''
+            ${cfg.package}/bin/webhook ${escapeShellArgs args}
+          '';
       };
     };
   };

--- a/nixos/modules/services/networking/wg-access-server.nix
+++ b/nixos/modules/services/networking/wg-access-server.nix
@@ -109,18 +109,9 @@ in
       wantedBy = [ "multi-user.target" ];
       requires = [ "network-online.target" ];
       after = [ "network-online.target" ];
-      script = ''
-        # merge secrets into main config
-        yq eval-all "select(fileIndex == 0) * select(fileIndex == 1)" ${configFile} $CREDENTIALS_DIRECTORY/SECRETS_FILE \
-          > "$STATE_DIRECTORY/config.yml"
-
-        ${lib.getExe cfg.package} serve --config "$STATE_DIRECTORY/config.yml"
-      '';
 
       path = with pkgs; [
         iptables
-        # needed by startup script
-        yq-go
       ];
 
       serviceConfig =
@@ -137,6 +128,14 @@ in
           LoadCredential = [
             "SECRETS_FILE:${cfg.secretsFile}"
           ];
+
+          # merge secrets into main config
+          ExecStartPre = [
+            "${lib.getExe' pkgs.coreutils "install"} '${configFile}' \"$STATE_DIRECTORY/config.yml\""
+            "${lib.getExe pkgs.yq-go} eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' '${configFile}' --in-place \"$CREDENTIALS_DIRECTORY/SECRETS_FILE\""
+          ];
+
+          ExecStart = "${lib.getExe cfg.package} serve --config \"$STATE_DIRECTORY/config.yml\"";
 
           # Hardening
           DynamicUser = true;

--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -24,6 +24,7 @@ let
   inherit (lib.options) literalExpression mkOption;
   inherit (lib.strings) hasInfix replaceStrings;
   inherit (lib.trivial) flip pipe;
+  inherit (lib.meta) getExe';
 
   removeNulls = filterAttrs (_: v: v != null);
 
@@ -104,16 +105,15 @@ let
       description = "Wireguard dynamic endpoint refresh (${name})";
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
-      path = with pkgs; [
-        iproute2
-        systemd
-      ];
       # networkd doesn't automatically refresh peer endpoints.
       # See: https://github.com/systemd/systemd/issues/9911
-      script = ''
-        touch /etc/systemd/network/40-${name}.netdev
-        networkctl reload
-      '';
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = [
+          "-${lib.getExe' pkgs.coreutils "touch"} /etc/systemd/network/40-${name}.netdev"
+          "${getExe' pkgs.systemd "networkctl"} reload"
+        ];
+      };
     };
 
   # netdev config must be a real file (not a symlink to a store file)

--- a/nixos/modules/services/networking/xinetd.nix
+++ b/nixos/modules/services/networking/xinetd.nix
@@ -143,8 +143,7 @@ in
       description = "xinetd server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.xinetd ];
-      script = "exec xinetd -syslog daemon -dontfork -stayalive -f ${configFile}";
+      serviceConfig.ExecStart = "${lib.getExe pkgs.xinetd} -syslog daemon -dontfork -stayalive -f ${configFile}";
     };
   };
 }

--- a/nixos/modules/services/networking/xray.nix
+++ b/nixos/modules/services/networking/xray.nix
@@ -93,10 +93,8 @@ with lib;
         description = "xray Daemon";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
-        script = ''
-          exec "${cfg.package}/bin/xray" -config "$CREDENTIALS_DIRECTORY/config.json"
-        '';
         serviceConfig = {
+          ExecStart = "${cfg.package}/bin/xray -config %d/config.json";
           DynamicUser = true;
           LoadCredential = "config.json:${settingsFile}";
           CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_BIND_SERVICE";

--- a/nixos/modules/services/networking/zerobin.nix
+++ b/nixos/modules/services/networking/zerobin.nix
@@ -91,14 +91,14 @@ in
       enable = true;
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+      serviceConfig.ExecStartPre = [
+        "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.dataDir}"
+        "${lib.getExe' pkgs.coreutils "chown"} ${cfg.user} ${cfg.dataDir}"
+      ];
       serviceConfig.ExecStart = "${pkgs.zerobin}/bin/zerobin ${cfg.listenAddress} ${toString cfg.listenPort} false ${cfg.user} ${cfg.group} ${zerobin_config}";
       serviceConfig.PrivateTmp = "yes";
       serviceConfig.User = cfg.user;
       serviceConfig.Group = cfg.group;
-      preStart = ''
-        mkdir -p ${cfg.dataDir}
-        chown ${cfg.user} ${cfg.dataDir}
-      '';
     };
   };
 }

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -190,15 +190,6 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
 
-      preStart = lib.mkMerge [
-        ''
-          install -m 700 '${configFile}' "$RUNTIME_DIRECTORY/config.toml"
-        ''
-        (lib.mkIf (cfg.masterKeyFile != null) ''
-          ${lib.getExe pkgs.replace-secret} '${master-key-placeholder}' "$CREDENTIALS_DIRECTORY/master_key" "$RUNTIME_DIRECTORY/config.toml"
-        '')
-      ];
-
       environment = builtins.listToAttrs (
         builtins.map (secret: {
           name = secret.environment;
@@ -218,6 +209,12 @@ in
             secret: lib.mkIf (secret.setting != null) [ "${secret.name}:${secret.setting}" ]
           ) secrets-with-path
         );
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "install"} -m 700 '${configFile}' \"$RUNTIME_DIRECTORY/config.toml\""
+        ]
+        ++ lib.optionals (cfg.masterKeyFile != null) [
+          "${lib.getExe pkgs.replace-secret} '${master-key-placeholder}' \"$CREDENTIALS_DIRECTORY/master_key\" \"$RUNTIME_DIRECTORY/config.toml\""
+        ];
         ExecStart = "${lib.getExe cfg.package} --config-file-path \${RUNTIME_DIRECTORY}/config.toml";
         StateDirectory = "meilisearch";
         WorkingDirectory = "%S/meilisearch";

--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -375,10 +375,10 @@ in
             })
             // instance.environmentVariables;
 
-          preStart = "${execCommand} ${configArg} validate-config";
           serviceConfig = {
             User = instance.user;
             Group = instance.group;
+            ExecStartPre = "${execCommand} ${configArg} validate-config";
             ExecStart = "${execCommand} ${configArg}";
             Restart = "always";
             RestartSec = "5s";

--- a/nixos/modules/services/security/certmgr.nix
+++ b/nixos/modules/services/security/certmgr.nix
@@ -34,11 +34,6 @@ let
         [ spec ]
     ) (lib.attrValues cfg.specs)
   );
-
-  preStart = ''
-    ${lib.concatStringsSep " \\\n" ([ "mkdir -p" ] ++ map lib.escapeShellArg specPaths)}
-    ${cfg.package}/bin/certmgr -f ${certmgrYaml} check
-  '';
 in
 {
   options.services.certmgr = {
@@ -215,11 +210,14 @@ in
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
-      inherit preStart;
 
       serviceConfig = {
         Restart = "always";
         RestartSec = "10s";
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p ${lib.escapeShellArgs specPaths}"
+          "${lib.getExe cfg.package} -f ${certmgrYaml} check"
+        ];
         ExecStart = "${cfg.package}/bin/certmgr -f ${certmgrYaml}";
       };
     };

--- a/nixos/modules/services/security/hologram-agent.nix
+++ b/nixos/modules/services/security/hologram-agent.nix
@@ -55,10 +55,8 @@ in
         "network-link-dummy0.service"
         "network-addresses-dummy0.service"
       ];
-      preStart = ''
-        /run/current-system/sw/bin/rm -fv /run/hologram.sock
-      '';
       serviceConfig = {
+        ExecStartPre = "/run/current-system/sw/bin/rm -fv /run/hologram.sock";
         ExecStart = "${pkgs.hologram}/bin/hologram-agent -debug -conf ${cfgFile} -port ${cfg.httpPort}";
       };
     };

--- a/nixos/modules/services/web-apps/bluemap.nix
+++ b/nixos/modules/services/web-apps/bluemap.nix
@@ -298,10 +298,8 @@ in
         Type = "oneshot";
         Group = "nginx";
         UMask = "026";
+        ExecStart = "${lib.getExe pkgs.bluemap} -c ${configFolder} -gs -r";
       };
-      script = ''
-        ${lib.getExe pkgs.bluemap} -c ${configFolder} -gs -r
-      '';
     };
 
     systemd.timers."render-bluemap-maps" = lib.mkIf cfg.enableRender {

--- a/nixos/modules/services/web-apps/cloudlog.nix
+++ b/nixos/modules/services/web-apps/cloudlog.nix
@@ -383,37 +383,44 @@ in
         cloudlog-upload-lotw = {
           description = "Upload QSOs to LoTW if certs have been provided";
           enable = cfg.upload-lotw.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/lotw/lotw_upload";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/lotw/lotw_upload";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-lotw-users = {
           description = "Update LOTW Users Database";
           enable = cfg.update-lotw-users.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/lotw/load_users";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/lotw/load_users";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-dok = {
           description = "Update DOK File for autocomplete";
           enable = cfg.update-dok.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_dok";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_dok";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-clublog-scp = {
           description = "Update Clublog SCP Database File";
           enable = cfg.update-clublog-scp.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_clublog_scp";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_clublog_scp";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-wwff = {
           description = "Update WWFF File for autocomplete";
           enable = cfg.update-wwff.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_wwff";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_wwff";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-upload-qrz = {
           description = "Upload QSOs to QRZ Logbook";
           enable = cfg.upload-qrz.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/qrz/upload";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/qrz/upload";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-sota = {
           description = "Update SOTA File for autocomplete";
           enable = cfg.update-sota.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_sota";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_sota";
+          serviceConfig.Type = "oneshot";
         };
       };
       timers = {

--- a/nixos/modules/services/web-apps/galene.nix
+++ b/nixos/modules/services/web-apps/galene.nix
@@ -133,19 +133,16 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        ${optionalString (cfg.insecure != true && cfg.certFile != null && cfg.keyFile != null) ''
-          install -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.certFile} ${cfg.dataDir}/cert.pem
-          install -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.keyFile} ${cfg.dataDir}/key.pem
-        ''}
-      '';
-
       serviceConfig = mkMerge [
         {
           Type = "simple";
           User = cfg.user;
           Group = cfg.group;
           WorkingDirectory = cfg.stateDir;
+          ExecStartPre = lib.mkIf (cfg.insecure != true && cfg.certFile != null && cfg.keyFile != null) [
+            "${lib.getExe' pkgs.coreutils "install"} -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.certFile} ${cfg.dataDir}/cert.pem"
+            "${lib.getExe' pkgs.coreutils "install"} -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.keyFile} ${cfg.dataDir}/key.pem"
+          ];
           ExecStart = ''
             ${cfg.package}/bin/galene \
             ${optionalString (cfg.insecure) "-insecure"} \

--- a/nixos/modules/services/web-apps/glitchtip.nix
+++ b/nixos/modules/services/web-apps/glitchtip.nix
@@ -236,11 +236,8 @@ in
         glitchtip = commonService // {
           description = "GlitchTip";
 
-          preStart = ''
-            ${lib.getExe pkg} migrate
-          '';
-
           serviceConfig = commonServiceConfig // {
+            ExecStartPre = "${lib.getExe pkg} migrate";
             ExecStart = ''
               ${lib.getExe python.pkgs.gunicorn} \
                 --bind=${cfg.listenAddress}:${toString cfg.port} \

--- a/nixos/modules/services/web-apps/healthchecks.nix
+++ b/nixos/modules/services/web-apps/healthchecks.nix
@@ -237,14 +237,13 @@ in
           wantedBy = [ "healthchecks.target" ];
           after = [ "healthchecks-migration.service" ];
 
-          preStart = ''
-            ${pkg}/opt/healthchecks/manage.py collectstatic --no-input
-            ${pkg}/opt/healthchecks/manage.py remove_stale_contenttypes --no-input
-          ''
-          + lib.optionalString (cfg.settings.DEBUG != "True") "${pkg}/opt/healthchecks/manage.py compress";
-
           serviceConfig = commonConfig // {
             Restart = "always";
+            ExecStartPre = [
+              "${pkg}/opt/healthchecks/manage.py collectstatic --no-input"
+              "${pkg}/opt/healthchecks/manage.py remove_stale_contenttypes --no-input"
+            ]
+            ++ lib.optionals (cfg.settings.DEBUG != "True") [ "${pkg}/opt/healthchecks/manage.py compress" ];
             ExecStart = ''
               ${pkgs.python3Packages.gunicorn}/bin/gunicorn hc.wsgi \
                 --bind ${cfg.listenAddress}:${toString cfg.port} \

--- a/nixos/modules/services/web-apps/hedgedoc.nix
+++ b/nixos/modules/services/web-apps/hedgedoc.nix
@@ -295,23 +295,21 @@ in
       documentation = [ "https://docs.hedgedoc.org/" ];
       wantedBy = [ "multi-user.target" ];
       after = [ "networking.target" ];
-      preStart =
-        let
-          configFile = settingsFormat.generate "hedgedoc-config.json" {
-            production = cfg.settings;
-          };
-        in
-        ''
-          ${pkgs.envsubst}/bin/envsubst \
-            -o /run/${name}/config.json \
-            -i ${configFile}
-          ${pkgs.coreutils}/bin/mkdir -p ${cfg.settings.uploadsPath}
-        '';
       serviceConfig = {
         User = name;
         Group = name;
 
         Restart = "always";
+        ExecStartPre =
+          let
+            configFile = settingsFormat.generate "hedgedoc-config.json" {
+              production = cfg.settings;
+            };
+          in
+          [
+            "${pkgs.envsubst}/bin/envsubst -o /run/${name}/config.json -i ${configFile}"
+            "${pkgs.coreutils}/bin/mkdir -p ${cfg.settings.uploadsPath}"
+          ];
         ExecStart = lib.getExe cfg.package;
         RuntimeDirectory = [ name ];
         StateDirectory = [ name ];

--- a/nixos/modules/services/web-apps/honk.nix
+++ b/nixos/modules/services/web-apps/honk.nix
@@ -129,21 +129,26 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       bindsTo = [ "honk-initdb.service" ];
-      preStart = ''
-        mkdir -p $STATE_DIRECTORY/views
-        ${lib.optionalString (cfg.extraJS != null) "ln -fs ${cfg.extraJS} $STATE_DIRECTORY/views/local.js"}
-        ${lib.optionalString (
-          cfg.extraCSS != null
-        ) "ln -fs ${cfg.extraCSS} $STATE_DIRECTORY/views/local.css"}
-        ${lib.getExe cfg.package} -datadir $STATE_DIRECTORY -viewdir ${cfg.package}/share/honk backup $STATE_DIRECTORY/backup
-        ${lib.getExe cfg.package} -datadir $STATE_DIRECTORY -viewdir ${cfg.package}/share/honk upgrade
-        ${lib.getExe cfg.package} -datadir $STATE_DIRECTORY -viewdir ${cfg.package}/share/honk cleanup
-      '';
       serviceConfig = {
+        ExecStartPre = [
+          "${lib.getExe cfg.package} -datadir $STATE_DIRECTORY -viewdir ${cfg.package}/share/honk backup $STATE_DIRECTORY/backup"
+          "${lib.getExe cfg.package} -datadir $STATE_DIRECTORY -viewdir ${cfg.package}/share/honk upgrade"
+          "${lib.getExe cfg.package} -datadir $STATE_DIRECTORY -viewdir ${cfg.package}/share/honk cleanup"
+        ];
         ExecStart = ''
           ${lib.getExe cfg.package} -datadir $STATE_DIRECTORY -viewdir ${cfg.package}/share/honk
         '';
-        StateDirectory = "honk";
+        StateDirectory = [
+          "honk"
+          "honk/views"
+        ];
+        BindReadOnlyPaths =
+          lib.optionals (cfg.extraJS != null) [
+            "${cfg.extraJS}:/var/lib/honk/views/local.js"
+          ]
+          ++ lib.optionals (cfg.extraCSS != null) [
+            "${cfg.extraCSS}:/var/lib/honk/views/local.css"
+          ];
         DynamicUser = true;
         PrivateTmp = "yes";
         Restart = "on-failure";

--- a/nixos/modules/services/web-apps/karakeep.nix
+++ b/nixos/modules/services/web-apps/karakeep.nix
@@ -184,18 +184,20 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       partOf = [ "karakeep.service" ];
-      script = ''
-        export HOME="$CACHE_DIRECTORY"
-        exec ${cfg.browser.exe} \
-          --headless --no-sandbox --disable-gpu --disable-dev-shm-usage \
-          --remote-debugging-address=127.0.0.1 \
-          --remote-debugging-port=${toString cfg.browser.port} \
-          --hide-scrollbars \
-          --user-data-dir="$STATE_DIRECTORY"
-      '';
+      environnment.HOME = "%C";
+
       serviceConfig = {
         Type = "simple";
         Restart = "on-failure";
+
+        ExecStart = ''
+          ${cfg.browser.exe} \
+            --headless --no-sandbox --disable-gpu --disable-dev-shm-usage \
+            --remote-debugging-address=127.0.0.1 \
+            --remote-debugging-port=${toString cfg.browser.port} \
+            --hide-scrollbars \
+            --user-data-dir="$STATE_DIRECTORY"
+        '';
 
         CacheDirectory = "karakeep-browser";
         StateDirectory = "karakeep-browser";

--- a/nixos/modules/services/web-apps/mediagoblin.nix
+++ b/nixos/modules/services/web-apps/mediagoblin.nix
@@ -310,19 +310,6 @@ in
       in
       {
         mediagoblin-celeryd = lib.recursiveUpdate serviceDefaults {
-          # we cannot change DEFAULT.data_dir inside mediagoblin.ini because of an annoying bug
-          # https://todo.sr.ht/~mediagoblin/mediagoblin/57
-          preStart = ''
-            cp --remove-destination ${
-              pkgs.writeText "mediagoblin.ini" (
-                lib.generators.toINI { } (lib.filterAttrsRecursive (n: v: n != "plugins") cfg.settings)
-                + "\n"
-                + lib.generators.toINI { mkKeyValue = mkSubSectionKeyValue 2; } {
-                  inherit (cfg.settings.mediagoblin) plugins;
-                }
-              )
-            } /var/lib/mediagoblin/mediagoblin.ini
-          '';
           serviceConfig = {
             Environment = [
               "CELERY_CONFIG_MODULE=mediagoblin.init.celery.from_celery"
@@ -331,6 +318,19 @@ in
               "MEDIAGOBLIN_CONFIG=/var/lib/mediagoblin/mediagoblin.ini"
               "PASTE_CONFIG=${pasteConfig}"
             ];
+            # we cannot change DEFAULT.data_dir inside mediagoblin.ini because of an annoying bug
+            # https://todo.sr.ht/~mediagoblin/mediagoblin/57
+            ExecStartPre = ''
+              ${lib.getExe' pkgs.coreutils "cp"} --remove-destination ${
+                pkgs.writeText "mediagoblin.ini" (
+                  lib.generators.toINI { } (lib.filterAttrsRecursive (n: v: n != "plugins") cfg.settings)
+                  + "\n"
+                  + lib.generators.toINI { mkKeyValue = mkSubSectionKeyValue 2; } {
+                    inherit (cfg.settings.mediagoblin) plugins;
+                  }
+                )
+              } /var/lib/mediagoblin/mediagoblin.ini
+            '';
             ExecStart = "${lib.getExe' finalPackage "celery"} worker --loglevel=INFO";
           };
           unitConfig.Description = "MediaGoblin Celery";
@@ -345,15 +345,15 @@ in
             "mediagoblin-celeryd.service"
             "postgresql.target"
           ];
-          preStart = ''
-            cp --remove-destination ${pasteConfig} /var/lib/mediagoblin/paste.ini
-            ${lib.getExe' finalPackage "gmg"} dbupdate
-          '';
           serviceConfig = {
             Environment = [
               "CELERY_ALWAYS_EAGER=false"
               "GI_TYPELIB_PATH=${GI_TYPELIB_PATH}"
               "GST_PLUGIN_PATH=${GST_PLUGIN_PATH}"
+            ];
+            ExecStartPre = [
+              "${lib.getExe' pkgs.coreutils "cp"} --remove-destination ${pasteConfig} /var/lib/mediagoblin/paste.ini"
+              "${lib.getExe' finalPackage "gmg"} dbupdate"
             ];
             ExecStart = "${lib.getExe' finalPackage "paster"} serve /var/lib/mediagoblin/paste.ini";
           };

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -18,14 +18,6 @@ let
   cfg = config.services.miniflux;
 
   boolToInt = b: if b then 1 else 0;
-
-  pgbin = "${config.services.postgresql.package}/bin";
-  # The hstore extension is no longer needed as of v2.2.14
-  # and would prevent Miniflux from starting.
-  preStart = pkgs.writeScript "miniflux-pre-start" ''
-    #!${pkgs.runtimeShell}
-    ${pgbin}/psql "miniflux" -c "DROP EXTENSION IF EXISTS hstore"
-  '';
 in
 
 {
@@ -141,7 +133,9 @@ in
       serviceConfig = {
         Type = "oneshot";
         User = config.services.postgresql.superUser;
-        ExecStart = preStart;
+        # The hstore extension is no longer needed as of v2.2.14
+        # and would prevent Miniflux from starting.
+        ExecStart = ''${config.services.postgresql.package}/bin/psql "miniflux" -c "DROP EXTENSION IF EXISTS hstore"'';
       };
     };
 

--- a/nixos/modules/services/web-apps/misskey.nix
+++ b/nixos/modules/services/web-apps/misskey.nix
@@ -326,19 +326,19 @@ in
       environment = {
         MISSKEY_CONFIG_YML = "/run/misskey/default.yml";
       };
-      preStart = ''
-        install -m 700 ${settingsFormat.generate "misskey-config.yml" cfg.settings} /run/misskey/default.yml
-      ''
-      + (lib.optionalString (cfg.database.passwordFile != null) ''
-        ${pkgs.replace-secret}/bin/replace-secret '@DATABASE_PASSWORD@' "${cfg.database.passwordFile}" /run/misskey/default.yml
-      '')
-      + (lib.optionalString (cfg.redis.passwordFile != null) ''
-        ${pkgs.replace-secret}/bin/replace-secret '@REDIS_PASSWORD@' "${cfg.redis.passwordFile}" /run/misskey/default.yml
-      '')
-      + (lib.optionalString (cfg.meilisearch.keyFile != null) ''
-        ${pkgs.replace-secret}/bin/replace-secret '@MEILISEARCH_KEY@' "${cfg.meilisearch.keyFile}" /run/misskey/default.yml
-      '');
       serviceConfig = {
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "install"} -m 700 ${settingsFormat.generate "misskey-config.yml" cfg.settings} /run/misskey/default.yml"
+        ]
+        ++ (lib.optionals (cfg.database.passwordFile != null) [
+          "${lib.getExe pkgs.replace-secret} '@DATABASE_PASSWORD@' '${cfg.database.passwordFile}' /run/misskey/default.yml"
+        ])
+        ++ (lib.optionals (cfg.redis.passwordFile != null) [
+          "${lib.getExe pkgs.replace-secret} '@REDIS_PASSWORD@' '${cfg.redis.passwordFile}' /run/misskey/default.yml"
+        ])
+        ++ (lib.optionals (cfg.meilisearch.keyFile != null) [
+          "${lib.getExe pkgs.replace-secret} '@MEILISEARCH_KEY@' '${cfg.meilisearch.keyFile}' /run/misskey/default.yml"
+        ]);
         ExecStart = "${cfg.package}/bin/misskey migrateandstart";
         RuntimeDirectory = "misskey";
         RuntimeDirectoryMode = "700";

--- a/nixos/modules/services/web-apps/nexus.nix
+++ b/nixos/modules/services/web-apps/nexus.nix
@@ -142,9 +142,8 @@ in
         fi
       '';
 
-      script = "${cfg.package}/bin/nexus run";
-
       serviceConfig = {
+        ExecStart = "${cfg.package}/bin/nexus run";
         User = cfg.user;
         Group = cfg.group;
         PrivateTmp = true;

--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -200,6 +200,7 @@ in
           requires = [ "postgresql.target" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
+            ExecStart = "${lib.getExe cfg.phpPackage} ${lib.getExe' cfg.package "console"} doctrine:migrations:migrate --no-interaction";
             Type = "oneshot";
             RemainAfterExit = true;
             User = "part-db";
@@ -207,10 +208,6 @@ in
           restartTriggers = [
             cfg.package
           ];
-          script = ''
-            set -euo pipefail
-            ${lib.getExe cfg.phpPackage} ${lib.getExe' cfg.package "console"} doctrine:migrations:migrate --no-interaction
-          '';
         };
 
         phpfpm-part-db = {

--- a/nixos/modules/services/web-apps/peering-manager.nix
+++ b/nixos/modules/services/web-apps/peering-manager.nix
@@ -307,11 +307,8 @@ in
           ]
           ++ lib.optionals (cfg.environmentFile != null) [ "peering-manager-config.service" ];
 
-          preStart = ''
-            ${pkg}/bin/peering-manager remove_stale_contenttypes --no-input
-          '';
-
           serviceConfig = {
+            ExecStartPre = "${pkg}/bin/peering-manager remove_stale_contenttypes --no-input";
             ExecStart = ''
               ${pkg.python.pkgs.gunicorn}/bin/gunicorn peering_manager.wsgi \
                 --bind ${cfg.listenAddress}:${toString cfg.port} \

--- a/nixos/modules/services/web-apps/plantuml-server.nix
+++ b/nixos/modules/services/web-apps/plantuml-server.nix
@@ -113,21 +113,22 @@ in
         PLANTUML_STATS = if cfg.plantumlStats then "on" else "off";
         HTTP_AUTHORIZATION = cfg.httpAuthorization;
       };
-      script = ''
-        ${cfg.packages.jdk}/bin/java \
-          -jar ${cfg.packages.jetty}/start.jar \
-            --module=deploy,http,jsp \
-            jetty.home=${cfg.packages.jetty} \
-            jetty.base=${cfg.package} \
-            jetty.http.host=${cfg.listenHost} \
-            jetty.http.port=${builtins.toString cfg.listenPort}
-      '';
 
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
         StateDirectory = mkIf (cfg.home == "/var/lib/plantuml") "plantuml";
         StateDirectoryMode = mkIf (cfg.home == "/var/lib/plantuml") "0750";
+
+        ExecStart = ''
+          ${cfg.packages.jdk}/bin/java \
+            -jar ${cfg.packages.jetty}/start.jar \
+              --module=deploy,http,jsp \
+              jetty.home=${cfg.packages.jetty} \
+              jetty.base=${cfg.package} \
+              jetty.http.host=${cfg.listenHost} \
+              jetty.http.port=${builtins.toString cfg.listenPort}
+        '';
 
         # Hardening
         AmbientCapabilities = [ "" ];

--- a/nixos/modules/services/web-apps/silverbullet.nix
+++ b/nixos/modules/services/web-apps/silverbullet.nix
@@ -95,7 +95,6 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = lib.mkIf (!lib.hasPrefix "/var/lib/" cfg.spaceDir) "mkdir -p '${cfg.spaceDir}'";
       serviceConfig = {
         Type = "simple";
         User = "${cfg.user}";
@@ -104,6 +103,9 @@ in
         StateDirectory = lib.mkIf (lib.hasPrefix "/var/lib/" cfg.spaceDir) (
           lib.last (lib.splitString "/" cfg.spaceDir)
         );
+        ExecStartPre = lib.mkIf (
+          !lib.hasPrefix "/var/lib/" cfg.spaceDir
+        ) "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.spaceDir}'";
         ExecStart =
           "${lib.getExe cfg.package} --port ${toString cfg.listenPort} --hostname '${cfg.listenAddress}' '${cfg.spaceDir}' "
           + lib.concatStringsSep " " cfg.extraArgs;

--- a/nixos/modules/services/web-apps/sogo.nix
+++ b/nixos/modules/services/web-apps/sogo.nix
@@ -151,15 +151,14 @@ in
       description = "SOGo tmpwatch";
 
       startAt = [ "hourly" ];
-      script = ''
-        SOGOSPOOL=/var/lib/sogo/spool
-
-        find "$SOGOSPOOL" -type f -user sogo -atime +23 -delete > /dev/null
-        find "$SOGOSPOOL" -mindepth 1 -type d -user sogo -empty -delete > /dev/null
-      '';
 
       serviceConfig = {
         Type = "oneshot";
+
+        ExecStart = [
+          "find /var/lib/sogo/spool -type f -user sogo -atime +23 -delete"
+          "find /var/lib/sogo/spool -mindepth 1 -type d -user sogo -empty -delete"
+        ];
 
         ProtectSystem = "strict";
         ProtectHome = true;

--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -143,10 +143,6 @@ in
       ++ optional (cfg.database.dialect == "postgres") "postgresql.target";
       wantedBy = [ "multi-user.target" ];
 
-      script = ''
-        exec ${getExe cfg.package} -config ${settingsFile}
-      '';
-
       serviceConfig = {
         Environment = mkMerge [
           (mkIf (cfg.passwordSalt != null) "WAKAPI_PASSWORD_SALT=${cfg.passwordSalt}")
@@ -156,6 +152,8 @@ in
         EnvironmentFile =
           (lib.optional (cfg.passwordSaltFile != null) cfg.passwordSaltFile)
           ++ (lib.optional (cfg.smtpPasswordFile != null) cfg.smtpPasswordFile);
+
+        ExecStart = "${getExe cfg.package} -config ${settingsFile}";
 
         User = config.users.users.wakapi.name;
         Group = config.users.users.wakapi.group;

--- a/nixos/modules/services/web-apps/wiki-js.nix
+++ b/nixos/modules/services/web-apps/wiki-js.nix
@@ -138,19 +138,18 @@ in
         openssh
       ];
 
-      preStart = ''
-        ln -sf ${configFile} /var/lib/${cfg.stateDirectoryName}/config.yml
-        ln -sf ${pkgs.wiki-js}/server /var/lib/${cfg.stateDirectoryName}
-        ln -sf ${pkgs.wiki-js}/assets /var/lib/${cfg.stateDirectoryName}
-        ln -sf ${pkgs.wiki-js}/package.json /var/lib/${cfg.stateDirectoryName}/package.json
-      '';
-
       serviceConfig = {
         EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
         StateDirectory = cfg.stateDirectoryName;
         WorkingDirectory = "/var/lib/${cfg.stateDirectoryName}";
         DynamicUser = true;
         PrivateTmp = true;
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${configFile} /var/lib/${cfg.stateDirectoryName}/config.yml"
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${pkgs.wiki-js}/server /var/lib/${cfg.stateDirectoryName}"
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${pkgs.wiki-js}/assets /var/lib/${cfg.stateDirectoryName}"
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${pkgs.wiki-js}/package.json /var/lib/${cfg.stateDirectoryName}/package.json"
+        ];
         ExecStart = "${pkgs.nodejs_20}/bin/node ${pkgs.wiki-js}/server";
       };
     };

--- a/nixos/modules/services/web-servers/h2o/default.nix
+++ b/nixos/modules/services/web-servers/h2o/default.nix
@@ -443,6 +443,7 @@ in
       ++ builtins.map (certName: "acme-${certName}.service") acmeCertNames.all;
 
       serviceConfig = {
+        ExecStartPre = "${h2oExe} --mode 'test'";
         ExecStart = "${h2oExe} --mode 'master'";
         ExecReload = [
           "${h2oExe} --mode 'test'"
@@ -483,8 +484,6 @@ in
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilitiesBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
       };
-
-      preStart = "${h2oExe} --mode 'test'";
     };
 
     # This service waits for all certificates to be available before reloading

--- a/nixos/modules/services/web-servers/jboss/default.nix
+++ b/nixos/modules/services/web-servers/jboss/default.nix
@@ -93,7 +93,7 @@ in
   config = mkIf config.services.jboss.enable {
     systemd.services.jboss = {
       description = "JBoss server";
-      script = "${jbossService}/bin/control start";
+      serviceConfig.ExecStart = "${jbossService}/bin/control start";
       wantedBy = [ "multi-user.target" ];
     };
   };

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -130,12 +130,9 @@ in
       startLimitBurst = 5;
       serviceConfig = {
         EnvironmentFile = cfg.environmentFiles;
-        ExecStartPre = lib.optional (cfg.environmentFiles != [ ]) (
-          pkgs.writeShellScript "pre-start" ''
-            umask 077
-            ${pkgs.envsubst}/bin/envsubst -i "${staticConfigFile}" > "${finalStaticConfigFile}"
-          ''
-        );
+        ExecStartPre = lib.optional (
+          cfg.environmentFiles != [ ]
+        ) "${pkgs.envsubst}/bin/envsubst -i '${staticConfigFile}' -o '${finalStaticConfigFile}'";
         ExecStart = "${cfg.package}/bin/traefik --configfile=${finalStaticConfigFile}";
         Type = "simple";
         User = "traefik";
@@ -152,6 +149,7 @@ in
         ProtectSystem = "full";
         ReadWritePaths = [ cfg.dataDir ];
         RuntimeDirectory = "traefik";
+        RuntimeDirectoryMode = "0700";
         WorkingDirectory = cfg.dataDir;
       };
     };

--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -116,9 +116,9 @@
           assert "1 timers listed." in timers, "incorrect number of timers"
 
           # Double check that our attrset option override works as expected
-          cmdline = node.succeed("grep 'paperless-manage' $(systemctl cat paperless-exporter | grep ExecStart | cut -f 2 -d=)")
+          cmdline = node.succeed("systemctl cat paperless-exporter | grep ExecStart | grep 'paperless-manage' | cut -f 2 -d=")
           print(f"Exporter command line {cmdline!r}")
-          assert cmdline.strip() == "paperless-manage document_exporter /var/lib/paperless/export --compare-checksums --delete --no-progress-bar --no-thumbnail", "Unexpected exporter command line"
+          assert cmdline.strip().endswith("paperless-manage document_exporter /var/lib/paperless/export --compare-checksums --delete --no-progress-bar --no-thumbnail"), "Unexpected exporter command line"
 
     test_paperless(simple)
     simple.send_monitor_command("quit")


### PR DESCRIPTION
<details>

<summary>Nixos test coverage overview</summary>

- [X] authelia
- [ ] autofs
- [ ] bluemap
- [ ] boinc
- [X] certmgr
- [X] cloudlog
- [X] cyrus-imap
- [X] dictd
- [ ] dkimproxy-out
- [ ] dnscache
- [X] docker-registry
- [ ] errbot
- [ ] freeradius
- [X] galene
- [X] geth
- [X] glitchtip
- [X] gollum
- [X] h2o
- [X] healthchecks
- [ ] heartbeat
- [ ] hologram-agent
- [ ] ircd-hybrid
- [ ] jboss
- [ ] journalbeat
- [ ] journaldriver
- [ ] mediagoblin
- [ ] minetest-server
- [ ] miniflux ([broken on master](https://hydra.nixos.org/build/310058942), see #444413)
- [X] misskey
- [X] ncps
- [X] nexus
- [X] nghttpx
- [ ] nm-file-secret-agent
- [ ] nullmailer
- [ ] oink
- [ ] opengfw
- [ ] ostinato
- [X] pangolin
- [X] paperless
- [ ] part-db
- [ ] pdnsd
- [ ] peering-manager (depends on broken package)
- [ ] pommed
- [ ] postgrey
- [X] prometheus-exporters/pgbouncer ([in `nixos/tests/prometheus-exporters.nix`](https://github.com/NixOS/nixpkgs/blob/faa5de48201f6158e8a7898b181beac4c82e1439/nixos/tests/prometheus-exporters.nix#L1149-L1190))
- [ ] promtail
- [ ] redsocks
- [X] silverbullet
- [ ] slurm
- [X] smokeping
- [ ] soteria
- [X] stalwart-mail
- [ ] supybot
- [x] svnserve
- [ ] syslog-ng
- [X] tailscale (indirectly available via `nixosTests.headscale`)
- [X] tandoor-recipes
- [X] thelounge
- [X] tinydns
- [ ] toxvpn
- [X] twingate
- [X] wakapi
- [ ] xinetd
- [ ] xray
- [ ] zerobin
- [X] zigbee2mqtt

</details>

<details>

<summary>Nixos test coverage overview 2</summary>

- [x] airsonic
- [x] alertmanager
- [ ] bcg
- [X] davis
- [ ] dnscache
- [X] ghostunnel
- [X] grafana
- [X] guix
- [X] hedgedoc
- [X] honk
- [X] invidious
- [ ] karakeep
- [X] keepalived
- [X] kthxbye
- [X] matrix-synapse
- [X] meilisearch
- [ ] mqtt2influxdb
- [ ] murmur
- [X] ncps
- [ ] openafs
- [ ] openvpn
- [ ] pdns
- [X] pihole-ftl
- [X] plantuml-server
- [ ] plex
- [ ] prometheus-exporters/junos-czerwonk
- [x] prometheus-exporters/mail
- [X] prosody
- [X] rosenpass
- [ ] sachet
- [X] sogo
- [X] telegraf
- [X] traefik
- [X] turn-rs
- [X] webhook
- [X] wg-access-server
- [X] wiki-js
- [X] wireguard
- [X] wireguard-networkd
- [ ] zitadel
- [X] zookeeper

</details>

Built tests with:

`NIXPKGS_ALLOW_UNFREE=1 NIXPKGS_ALLOW_INSECURE=1 nix build .#nixosTests.authelia .#nixosTests.certmgr.systemd .#nixosTests.cloudlog .#nixosTests.cyrus-imap .#nixosTests.docker-registry .#nixosTests.galene.basic .#nixosTests.galene.file-transfer .#nixosTests.geth .#nixosTests.glitchtip .#nixosTests.gollum .#nixosTests.h2o.basic .#nixosTests.h2o.mruby .#nixosTests.h2o.tls-recommendations .#nixosTests.headscale .#nixosTests.healthchecks .#nixosTests.misskey .#nixosTests.ncps .#nixosTests.nexus .#nixosTests.nghttpx .#nixosTests.pangolin .#nixosTests.paperless .#nixosTests.prometheus-exporters.pgbouncer .#nixosTests.silverbullet .#nixosTests.smokeping .#nixosTests.stalwart-mail .#nixosTests.tandoor-recipes .#nixosTests.tandoor-recipes-script-name .#nixosTests.thelounge .#nixosTests.tinydns .#nixosTests.twingate .#nixosTests.wakapi .#nixosTests.zigbee2mqtt --impure`
